### PR TITLE
Fix workflow: Add uv installation step

### DIFF
--- a/.github/workflows/update-lucide.yml
+++ b/.github/workflows/update-lucide.yml
@@ -27,6 +27,9 @@ jobs:
         python-version: '3.12'
         cache: pip
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
• Fix the Update Lucide Icons workflow by adding uv installation
• GitHub Actions runners don't have uv pre-installed
• This was causing the 'make lucide-db' command to fail

## Changes
- Add  action before dependency installation
- Ensures uv is available for Makefile commands

## Testing
- Workflow failed without this fix (run #15836613613)
- Will test again after merging this fix

🤖 Generated with [Claude Code](https://claude.ai/code)