### PR TITLE
fix(ci): correct token for pr creation

### DIFF
--- a/.github/workflows/update-lucide.yml
+++ b/.github/workflows/update-lucide.yml
@@ -174,7 +174,7 @@ jobs:
         🤖 *This PR was created automatically by the weekly Lucide update workflow.*
         "
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Summary
       if: always()


### PR DESCRIPTION
Fixes the workflow failure when creating a pull request by using secrets.GITHUB_TOKEN instead of github.token.