### PR TITLE
fix: properly escape quotes in Update Lucide Icons workflow

### DIFF
--- a/.github/workflows/update-lucide.yml
+++ b/.github/workflows/update-lucide.yml
@@ -79,14 +79,14 @@ jobs:
       run: |
         # Update Lucide tag in config.py
         NEW_LUCIDE_VERSION="${{ steps.version-check.outputs.latest-version }}"
-        sed -i "s/DEFAULT_LUCIDE_TAG = ".*"/DEFAULT_LUCIDE_TAG = "$NEW_LUCIDE_VERSION"/" src/lucide/config.py
+        sed -i "s/DEFAULT_LUCIDE_TAG = \".*\"/DEFAULT_LUCIDE_TAG = \"$NEW_LUCIDE_VERSION\"/" src/lucide/config.py
         echo "✅ Updated config.py to Lucide version $NEW_LUCIDE_VERSION"
 
         # Bump package version in pyproject.toml
         CURRENT_PKG_VERSION=$(grep "^version = " pyproject.toml | sed 's/version = "\(.*\)"/\1/')
         NEW_PKG_VERSION=$(uv run python -c "v = '$CURRENT_PKG_VERSION'.split('.'); v[-1] = str(int(v[-1]) + 1); print('.'.join(v))")
 
-        sed -i "s/version = ".*"/version = "$NEW_PKG_VERSION"/" pyproject.toml
+        sed -i "s/version = \".*\"/version = \"$NEW_PKG_VERSION\"/" pyproject.toml
         echo "✅ Bumped package version from $CURRENT_PKG_VERSION to $NEW_PKG_VERSION"
 
         echo "new-pkg-version=$NEW_PKG_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fixed failing Update Lucide Icons workflow by properly escaping quotes in sed commands
- Prevents invalid TOML syntax when updating version strings

## Problem
The workflow was failing with a TOML parse error:
```
TOML parse error at line 37, column 14
   |
37 | version = 0.2.2
   |              ^^
invalid float, expected nothing
```

This occurred because the sed commands were stripping quotes from version strings:
- `version = "0.2.1"` → `version = 0.2.2` (missing quotes)

## Solution
Fixed the sed commands to properly escape quotes:
- Line 82: `sed -i "s/DEFAULT_LUCIDE_TAG = \".*\"/DEFAULT_LUCIDE_TAG = \"$NEW_LUCIDE_VERSION\"/"` 
- Line 89: `sed -i "s/version = \".*\"/version = \"$NEW_PKG_VERSION\"/"`

## Test plan
- [x] Tested sed commands locally to verify proper quote preservation
- [x] Ran `make run-hooks-all-files` - all checks pass
- [ ] Workflow will be tested when it runs next (scheduled for Mondays or can be manually triggered)

🤖 Generated with [Claude Code](https://claude.ai/code)