### PR TITLE
fix: make sed command more precise for version update in workflow

### DIFF
--- a/.github/workflows/update-lucide.yml
+++ b/.github/workflows/update-lucide.yml
@@ -86,7 +86,7 @@ jobs:
         CURRENT_PKG_VERSION=$(grep "^version = " pyproject.toml | sed 's/version = "\(.*\)"/\1/')
         NEW_PKG_VERSION=$(uv run python -c "v = '$CURRENT_PKG_VERSION'.split('.'); v[-1] = str(int(v[-1]) + 1); print('.'.join(v))")
 
-        sed -i "s/version = \".*\"/version = \"$NEW_PKG_VERSION\"/" pyproject.toml
+        sed -i "s/^version = \".*\"/version = \"$NEW_PKG_VERSION\"/" pyproject.toml
         echo "✅ Bumped package version from $CURRENT_PKG_VERSION to $NEW_PKG_VERSION"
 
         echo "new-pkg-version=$NEW_PKG_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fixed overly broad sed command in Update Lucide Icons workflow
- Prevents replacement of multiple version-related fields in pyproject.toml

## Problem
The workflow was failing with error:
```
error: Failed to install: python_lucide-0.2.2-py3-none-any.whl (python-lucide==0.2.2 (from file:///home/runner/work/python-lucide/python-lucide))
  Caused by: The wheel is invalid: invalid console script: '0.2.2'
```

This happened because the sed command `s/version = \".*\"/version = \"$NEW_PKG_VERSION\"/` was too broad and replaced multiple fields:
- ✅ `version = "0.2.1"` → `version = "0.2.2"` (intended)
- ❌ `python_version = "3.10"` → `python_version = "0.2.2"` (unintended)
- ❌ `target-version = "py310"` → `target-version = "0.2.2"` (unintended)
- ❌ `check-lucide-version = "..."` → `check-lucide-version = "0.2.2"` (unintended)

## Solution
Made the sed command more precise by anchoring it to the beginning of the line:
```bash
sed -i "s/^version = \".*\"/version = \"$NEW_PKG_VERSION\"/" pyproject.toml
```

This ensures only the project version line is updated, not other version-related fields.

## Test plan
- [x] Tested sed command locally - only project version line is modified
- [x] Verified other version fields remain unchanged
- [ ] Workflow will be tested when it runs next

🤖 Generated with [Claude Code](https://claude.ai/code)