### PR TITLE
fix: remove API token to use trusted publishing properly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,6 @@ jobs:
     - name: Publish package to PyPI
       run: |
         uv publish
-      env:
-        # Use API token if available, otherwise rely on trusted publishing
-        UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN || '' }}
 
     # Optional: Create GitHub Release with assets
     - name: Upload assets to GitHub Release


### PR DESCRIPTION
## Summary
Fix the 403 authentication error during package publishing by removing the API token configuration to use trusted publishing properly.

## Problem
The deployment action was failing with:
```
error: Failed to publish `dist/python_lucide-0.2.2-py3-none-any.whl` to https://upload.pypi.org/legacy/
  Caused by: Upload failed with status code 403 Forbidden. Server says: 403 Invalid or non-existent authentication information.
```

## Root Cause
The workflow was setting `UV_PUBLISH_TOKEN` environment variable, which made uv try to use token-based authentication instead of the trusted publishing setup that's already configured on PyPI.

## Solution
Remove the `UV_PUBLISH_TOKEN` environment variable entirely so `uv publish` will automatically detect and use the OIDC token provided by GitHub Actions for trusted publishing.

## Verification
This matches the existing PyPI trusted publisher configuration:
- **Repository**: `mmacpherson/python-lucide`
- **Workflow**: `publish.yml`  
- **Environment**: `(Any)`

With the `id-token: write` permission already in the workflow, GitHub automatically provides an OIDC token that PyPI trusts. uv detects this automatically when no explicit token is provided.

## Result
The deployment action should now publish successfully using trusted publishing without needing to manage API tokens\! 🚀

🤖 Generated with [Claude Code](https://claude.ai/code)