### PR TITLE
fix: grant contents:write to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # This permission is needed for private packages
-      contents: read
+      contents: write
       id-token: write  # This is required for OIDC publishing
 
     steps:


### PR DESCRIPTION
## Summary

- Change `contents: read` to `contents: write` in the publish workflow so the `softprops/action-gh-release` step can attach build artifacts (wheel + tarball) to the GitHub release

The v0.2.28 release published to PyPI successfully but the workflow reported failure because the asset upload step lacked write permission.

## Test plan

- [ ] Verify next release upload step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)