### PR TITLE
fix(ci): compute-embeddings path doubled web/ prefix

### DIFF
--- a/.github/workflows/deploy-search.yml
+++ b/.github/workflows/deploy-search.yml
@@ -56,7 +56,7 @@ jobs:
       run: uv run python web/scripts/export-data.py
 
     - name: Compute embeddings
-      run: node web/scripts/compute-embeddings.mjs
+      run: node scripts/compute-embeddings.mjs
       working-directory: web
 
     - name: Build Vite app


### PR DESCRIPTION
First deploy-search run failed at the Compute embeddings step: the step has `working-directory: web` but passed `web/scripts/compute-embeddings.mjs`, resolving to `web/web/scripts/`. Run log: https://github.com/mmacpherson/python-lucide/actions/runs/27257210634

🤖 Generated with [Claude Code](https://claude.com/claude-code)