### PR TITLE
feat(web): multilingual example chips when the multilingual model is active

### DIFF
--- a/web/src/pages/SearchPage.svelte
+++ b/web/src/pages/SearchPage.svelte
@@ -141,6 +141,21 @@
     "secure login with a password",
   ];
 
+  // Per-model overrides, curated the same way. The multilingual set mixes
+  // languages to demonstrate the model's coverage — these would retrieve
+  // junk on the English-only models, so they only appear here.
+  const EXAMPLES_BY_MODEL: Record<string, string[]> = {
+    multilingual: [
+      "viajar a algún lugar en avión",
+      "das Wetter wird kälter",
+      "パスワードで安全にログイン",
+      "庆祝一个重大成就",
+      "notifications are turned off",
+    ],
+  };
+
+  const examples = $derived(EXAMPLES_BY_MODEL[activeModelId] ?? EXAMPLES);
+
   function runExample(q: string) {
     query = q;
     doSearch(q);
@@ -184,7 +199,7 @@
     {#if !query && ready}
       <div class="examples">
         <span class="ex-label">Try</span>
-        {#each EXAMPLES as example}
+        {#each examples as example}
           <button class="chip" onclick={() => runExample(example)}>{example}</button>
         {/each}
       </div>


### PR DESCRIPTION
The "Try" example phrases now swap per model. When **Multilingual** is selected, the chips become one phrase each in Spanish, German, Japanese, and Chinese, plus one English:

| phrase | top results |
|---|---|
| viajar a algún lugar en avión | plane, plane-takeoff, plane-landing |
| das Wetter wird kälter | thermometer-snowflake, cloud-snow, sun-snow |
| パスワードで安全にログイン | key, user-key, user-lock |
| 庆祝一个重大成就 | trophy, party-popper, award |
| notifications are turned off | bell-off, alarm-clock-off, bell-minus |

Curated against the multilingual embeddings with the same eval used for the English set (candidates that retrieved poorly were dropped). The English-only models keep the existing chips — non-English phrases would retrieve junk there, so they only appear where clicking them works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)