### PR TITLE
feat(web): show python-lucide package version in the footer

### DIFF
--- a/web/scripts/export-data.py
+++ b/web/scripts/export-data.py
@@ -15,6 +15,7 @@ time — the browser only embeds the query, so Python and web search score
 against identical document vectors.
 """
 
+import importlib.metadata
 import json
 import sqlite3
 import sys
@@ -124,8 +125,14 @@ def export_icons(names: list[str]) -> None:
             }
         )
 
+    try:
+        package_version = importlib.metadata.version("python-lucide")
+    except importlib.metadata.PackageNotFoundError:
+        package_version = ""
+
     output = {
         "version": version,
+        "packageVersion": package_version,
         "models": _model_manifest(),
         "icons": icons,
     }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -23,6 +23,8 @@ export interface IconData {
 
 export interface IconsManifest {
   version: string;
+  /** python-lucide package version that exported this data ("" if unknown) */
+  packageVersion: string;
   models: ModelConfig[];
   icons: IconData[];
 }

--- a/web/src/pages/SearchPage.svelte
+++ b/web/src/pages/SearchPage.svelte
@@ -317,7 +317,7 @@
     {/if}
 
     <footer class="foot">
-      <span>powered by <a class="repo mono" href="https://github.com/mmacpherson/python-lucide" target="_blank" rel="noopener">python-lucide</a> &middot; {manifest.icons.length.toLocaleString()} icons shipped in SQLite</span>
+      <span>powered by <a class="repo mono" href="https://github.com/mmacpherson/python-lucide" target="_blank" rel="noopener">python-lucide</a>{#if manifest.packageVersion}&nbsp;<span class="mono dim">v{manifest.packageVersion}</span>{/if} &middot; {manifest.icons.length.toLocaleString()} icons shipped in SQLite</span>
       <span class="dim">embeddings computed in-browser via <a href="https://huggingface.co/docs/transformers.js" target="_blank">transformers.js</a></span>
     </footer>
   {/if}


### PR DESCRIPTION
Footer now reads `powered by python-lucide v0.4.0 · 1,713 icons shipped in SQLite`.

The export script stamps `importlib.metadata.version("python-lucide")` into the manifest as `packageVersion` (the deploy CI `uv sync`s the repo, so this is the released version), and the footer renders it after the repo link — omitted if metadata is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)