### PR TITLE
fix(web): mobile portrait layout

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -124,7 +124,7 @@
 <style>
   .glow {
     position: fixed; top: -180px; left: 50%; transform: translateX(-50%);
-    width: 760px; height: 340px;
+    width: min(760px, 100vw); height: 340px;
     background: radial-gradient(ellipse at center, var(--glow), transparent 70%);
     pointer-events: none; z-index: 0;
   }
@@ -210,5 +210,14 @@
   }
   .toast.show {
     opacity: 1; transform: translateX(-50%) translateY(0);
+  }
+
+  @media (max-width: 600px) {
+    .hdr { padding: 12px 16px; }
+    .hdr-r { gap: 6px; }
+    /* The brand mark + nav still identify the app; the wordmark suffix
+       and icon-set version don't earn their width on a phone */
+    .wm-dim, .ver { display: none; }
+    .main { padding: 22px 16px 0; }
   }
 </style>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -57,6 +57,15 @@ body {
   position: relative;
 }
 
+/* Rendered header height (content + padding + border); keep in sync with
+   .hdr in App.svelte. Pages that must fit the viewport (Explore) subtract
+   it instead of relying on flex stretch, which leaves child heights
+   "indefinite" and breaks percentage sizing. */
+:root { --hdr-h: 66px; }
+@media (max-width: 600px) {
+  :root { --hdr-h: 62px; }
+}
+
 a { color: var(--ac); text-decoration: none; }
 a:hover { text-decoration: underline; }
 ::selection { background: var(--acs); }

--- a/web/src/pages/ExplorePage.svelte
+++ b/web/src/pages/ExplorePage.svelte
@@ -79,7 +79,10 @@
     }
   }
 
-  function layoutPoints() {
+  // Width/height are CSS pixels: the draw context is dpr-scaled, so laying
+  // out in device pixels would shift everything by dpr× and clip the plot
+  // on high-density (phone) screens.
+  function layoutPoints(width: number, height: number) {
     if (!Object.keys(coords).length) return;
 
     const xs = Object.values(coords).map((c) => c[0]);
@@ -90,8 +93,8 @@
     const rangeY = maxY - minY || 1;
 
     const pad = 40;
-    const w = canvas.width - pad * 2;
-    const h = canvas.height - pad * 2;
+    const w = width - pad * 2;
+    const h = height - pad * 2;
 
     points = manifest.icons
       .map((icon, idx) => {
@@ -126,7 +129,7 @@
     canvas.height = rect.height * dpr;
     ctx.scale(dpr, dpr);
 
-    layoutPoints();
+    layoutPoints(rect.width, rect.height);
 
     ctx.clearRect(0, 0, rect.width, rect.height);
     ctx.save();
@@ -456,6 +459,12 @@
 <style>
   .explore {
     flex: 1; display: flex; position: relative; z-index: 1; min-height: 0;
+    /* Cap at the viewport so the absolutely positioned canvas and the
+       scrollable cluster list stay bounded. max-height, not height: flex:1
+       sets flex-basis:0%, which makes height ignored on the main axis.
+       dvh tracks mobile browser chrome where supported. */
+    max-height: calc(100vh - var(--hdr-h));
+    max-height: calc(100dvh - var(--hdr-h));
   }
 
   /* ── Sidebar ─────────────────────────────────────────────────── */
@@ -531,7 +540,10 @@
     background: radial-gradient(circle at 50% 42%, var(--hl), transparent 60%);
   }
   canvas {
-    width: 100%; height: 100%; display: block;
+    /* Absolute, not height:100%: in the stacked (column) phone layout the
+       flexed parent height isn't "definite", so a percentage height falls
+       back to the buffer's intrinsic aspect and squashes the plot */
+    position: absolute; inset: 0; width: 100%; height: 100%; display: block;
     cursor: grab;
   }
   .canvas-loading {
@@ -568,4 +580,17 @@
   .tooltip strong { font-family: var(--font-mono); font-size: 13px; }
   .tooltip p { font-size: 12px; color: var(--tx2); line-height: 1.4; margin: 0; }
   .tooltip-cluster { display: inline-block; margin-top: 4px; font-size: 11px; }
+
+  /* Portrait phones: plot on top, cluster list scrolls below it.
+     column-reverse keeps the DOM order (list first) for keyboard users.
+     Must come after the base rules above to override them. */
+  @media (max-width: 700px) {
+    .explore { flex-direction: column-reverse; }
+    .ex-list {
+      width: 100%; max-height: 34vh;
+      border-right: none; border-top: 1px solid var(--bd);
+    }
+    .ex-canvas { min-height: 52vh; }
+    .ex-hint { display: none; }
+  }
 </style>

--- a/web/src/pages/SearchPage.svelte
+++ b/web/src/pages/SearchPage.svelte
@@ -386,7 +386,7 @@
   }
   .meta-l { font-size: 13px; color: var(--tx2); }
   .meta-l b { color: var(--tx); font-weight: 700; }
-  .meta-r { display: flex; align-items: center; gap: 11px; }
+  .meta-r { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
   .model { font-size: 11px; color: var(--tx3); }
   .mono { font-family: var(--font-mono); }
 
@@ -555,4 +555,10 @@
   .dim { color: var(--tx3); }
   .dim a { color: var(--tx2); }
   .dim a:hover { color: var(--tx); text-decoration: underline; }
+
+  @media (max-width: 640px) {
+    /* The full model filename is documented in the info popover; on a
+       phone it can't fit between the two toggles without wrapping badly */
+    .model { display: none; }
+  }
 </style>


### PR DESCRIPTION
The app was desktop-only CSS; on a portrait phone it had 137px of horizontal overflow and the Explore plot was clipped/squashed. Verified with Playwright at 390x844 dpr 2-3 and 1440x900 dpr 1, both pages, including search results and the detail panel — zero overflow everywhere, desktop unchanged.

**CSS (responsive)**
- glow capped at viewport width
- header: tighter padding, wordmark suffix + icon-set version hidden under 600px
- search meta row wraps; the verbose model filename is hidden under 640px (the info popover documents it)
- Explore stacks under 700px: plot on top, cluster list scrolls below (column-reverse keeps DOM order for keyboard users)

**Real bugs this surfaced**
- `layoutPoints()` laid points out in device pixels while the draw context is dpr-scaled — on phones (dpr 2-3) the whole plot rendered at 2-3x offset and was clipped. Now laid out in CSS pixels.
- The plot canvas used `height: 100%` against a flex-stretched parent whose height isn't definite in a column layout, collapsing it to its buffer's intrinsic aspect. The canvas is now absolutely positioned within `.ex-canvas`, and `.explore` is capped with `max-height: calc(100dvh - var(--hdr-h))` (max-height because `flex: 1` sets `flex-basis: 0%`, which makes `height` ignored on the main axis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)