### PR TITLE
feat(web): q8 English models, default to Faster

### DIFF
--- a/src/lucide/config.py
+++ b/src/lucide/config.py
@@ -35,8 +35,10 @@ class EmbeddingModelConfig:
         pooling: transformers.js pooling mode ("mean" or "cls").
         web_dtype: transformers.js quantization. Document vectors always
             come from fastembed (fp32), so a quantized browser model only
-            perturbs the query vector — q8 stays ~0.994 cosine to fp32,
-            which is ranking-equivalent, and roughly quarters the download.
+            perturbs the query vector — q8 stays ~0.985-0.996 cosine to
+            fp32 across our models, which is ranking-equivalent (top-1
+            changes are swaps between near-tied results), and roughly
+            quarters the download.
         query_prefix: Prefix prepended to queries (asymmetric retrieval).
         document_prefix: Prefix prepended to documents at build time.
         label: Human-facing label for the web UI model toggle.
@@ -60,6 +62,7 @@ EMBEDDING_MODELS: dict[str, EmbeddingModelConfig] = {
         web_model="Xenova/all-MiniLM-L6-v2",
         dim=384,
         pooling="mean",
+        web_dtype="q8",
         label="Faster",
     ),
     "bge-small": EmbeddingModelConfig(
@@ -68,6 +71,7 @@ EMBEDDING_MODELS: dict[str, EmbeddingModelConfig] = {
         web_model="Xenova/bge-small-en-v1.5",
         dim=384,
         pooling="cls",
+        web_dtype="q8",
         query_prefix="Represent this sentence for searching relevant passages: ",
         label="Better",
     ),
@@ -83,6 +87,11 @@ EMBEDDING_MODELS: dict[str, EmbeddingModelConfig] = {
 }
 
 DEFAULT_SEARCH_MODEL_ID = "bge-small"
+
+# The web app starts on the smallest model so first paint is a ~22 MB
+# download instead of ~33 MB; users opt into heavier models via the toggle.
+# Python keeps the strongest default since there's no download trade-off.
+DEFAULT_WEB_MODEL_ID = "minilm"
 
 # VLM used to generate icon descriptions at build time
 DEFAULT_VLM_MODEL = "gemini-2.5-flash-lite"

--- a/web/scripts/export-data.py
+++ b/web/scripts/export-data.py
@@ -24,7 +24,11 @@ from pathlib import Path
 import numpy as np
 import umap
 
-from lucide.config import DEFAULT_SEARCH_MODEL_ID, EMBEDDING_MODELS
+from lucide.config import (
+    DEFAULT_SEARCH_MODEL_ID,
+    DEFAULT_WEB_MODEL_ID,
+    EMBEDDING_MODELS,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DATA_DIR = REPO_ROOT / "src" / "lucide" / "data"
@@ -52,7 +56,10 @@ def _model_manifest() -> list[dict]:
             "dtype": cfg.web_dtype,
             "queryPrefix": cfg.query_prefix,
             "label": cfg.label,
-            "default": cfg.id == DEFAULT_SEARCH_MODEL_ID,
+            "default": cfg.id == DEFAULT_WEB_MODEL_ID,
+            # The model whose embeddings produced the UMAP layout and
+            # clusters; Explore must use the same space for neighbor lines
+            "clusterSource": cfg.id == DEFAULT_SEARCH_MODEL_ID,
         }
         for cfg in _web_models()
     ]

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -10,6 +10,8 @@ export interface ModelConfig {
   queryPrefix: string;
   label: string;
   default: boolean;
+  /** Model whose embeddings produced the UMAP layout and clusters */
+  clusterSource: boolean;
 }
 
 export interface IconData {

--- a/web/src/pages/ExplorePage.svelte
+++ b/web/src/pages/ExplorePage.svelte
@@ -332,7 +332,7 @@
       if (!resp.ok) throw new Error(`Failed to fetch umap-coords.json: HTTP ${resp.status}`);
       coords = await resp.json();
 
-      const model = manifest.models.find((m) => m.default) ?? manifest.models[0];
+      const model = manifest.models.find((m) => m.clusterSource) ?? manifest.models[0];
       embeddingDim = model.dim;
       embeddingsMatrix = await loadEmbeddings(
         `${BASE}data/${model.file}?v=${manifest.version}`, manifest.icons.length, model.dim,

--- a/web/src/pages/SearchPage.svelte
+++ b/web/src/pages/SearchPage.svelte
@@ -244,8 +244,8 @@
             <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
             <div class="info-pop" onclick={(e) => e.stopPropagation()}>
               <p>Search runs entirely in your browser: your query is embedded by a small neural net and matched against precomputed icon embeddings. Nothing is sent to a server.</p>
-              <p><b>Faster</b> uses <span class="mono">all-MiniLM-L6-v2</span> (~90&thinsp;MB) — quick to download, solid results.</p>
-              <p><b>Better</b> uses <span class="mono">bge-small-en-v1.5</span> (~130&thinsp;MB) — a larger model with noticeably stronger semantic ranking.</p>
+              <p><b>Faster</b> uses <span class="mono">all-MiniLM-L6-v2</span> (~22&thinsp;MB) — quick to download, solid results.</p>
+              <p><b>Better</b> uses <span class="mono">bge-small-en-v1.5</span> (~33&thinsp;MB) — a larger model with noticeably stronger semantic ranking.</p>
               <p><b>Multilingual</b> uses <span class="mono">paraphrase-multilingual-MiniLM-L12-v2</span> (~115&thinsp;MB) — search in 50+ languages (for English, Better ranks best).</p>
               <p>Each model downloads once on first use, then loads from browser cache.</p>
               <p>Tip: descriptive phrases ("waiting for a download") match better than single keywords.</p>


### PR DESCRIPTION
| | before | after |
|---|---|---|
| Faster (minilm) | 87 MB fp32 | **22 MB q8** — now the default |
| Better (bge-small) | 127 MB fp32 | **33 MB q8** |
| Multilingual | 113 MB q8 | unchanged |

Document vectors are always exact fastembed fp32, so browser quantization only perturbs the query vector. Measured: 0.991/0.996 mean cosine to fp32 (minilm/bge-small), 9+/10 top-10 overlap, and every top-1 change across probe queries was a swap between near-tied results (e.g. award↔trophy at 40.3 vs 40.3).

Also evaluated **bge-base-en-v1.5** and **snowflake-arctic-embed-m** (both 104 MB q8) as a bigger Better: bge-base ranked worse on several prompts ("an idea just occurred to me" → contrast/mirror-round vs bge-small's lightbulb/brain) and arctic-m was inconsistent with score calibration ~0.2 that would break the UI score badges. bge-small stays.

Plumbing: new `DEFAULT_WEB_MODEL_ID` so the app default and the Python CLI default (still bge-small) are independent; Explore now selects its embedding space via a `clusterSource` manifest flag (the model that produced the UMAP layout/clusters) rather than following the web default.

No DB or release changes needed — all three models are already in the published search DB. Verified end-to-end in chromium: boots on Faster, q8 models load, "secure login with a password" → key-round/lock-keyhole/key on both models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)