### PR TITLE
feat(cli): document semantic search and clean up its first-run output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ in your Python projects, with no javascript in sight.
 
 ## Features
 - 🎨 **Access 1600+ Lucide icons** directly from Python
+- 🔍 **Semantic search** - find icons by meaning, in the terminal or [in the browser](https://mmacpherson.github.io/python-lucide/search/)
 - 🛠 **Customize icons** with classes, sizes, colors, and other SVG attributes
 - 🚀 **Framework-friendly** with examples for FastHTML, Flask, Django, and more
 - 📦 **Lightweight** with minimal dependencies
@@ -57,6 +58,53 @@ lucide_icon("user", stroke="blue")        # Blue outline
 lucide_icon("user", fill="currentColor")  # Inherit color from CSS
 lucide_icon("user", stroke="#ff6b6b")     # Hex colors work too
 ```
+
+## Semantic Search
+
+Find icons by describing what you mean, not what they're called:
+
+```bash
+# One-off, no install (requires uv)
+uvx --from "python-lucide[search]" lucide search "celebrate a big achievement"
+
+# Or install the search extra
+pip install "python-lucide[search]"
+lucide search "waiting for a download"
+```
+
+```
+trophy        67%
+award         65%
+medal         65%
+party-popper  62%
+```
+
+Icons are matched against AI-generated descriptions using the same embedding
+model the [web app](https://mmacpherson.github.io/python-lucide/search/) uses,
+so descriptive phrases ("an idea just occurred to me") work better than
+keywords. Options:
+
+- `--model multilingual` — search in 50+ languages (default `bge-small` ranks
+  best for English)
+- `--limit N` — number of results; `--verbose` — include each icon's description
+- In terminals supporting the Kitty graphics protocol (kitty, Ghostty,
+  WezTerm), the icons themselves render inline with the results.
+
+The first search downloads the embedding model (~67 MB) and the pre-built
+search index (11 MB); both are cached, and every search after that runs
+locally in well under a second.
+
+The same search is available as a Python API:
+
+```python
+from lucide.search import search_icons
+
+for r in search_icons("secure login", limit=5):
+    print(r.name, r.score)
+```
+
+Prefer not to install anything? The [browser version](https://mmacpherson.github.io/python-lucide/search/)
+runs the whole pipeline client-side.
 
 ## Framework Integration Examples
 

--- a/src/lucide/cli.py
+++ b/src/lucide/cli.py
@@ -529,6 +529,40 @@ def _cmd_build_search(args: argparse.Namespace) -> int:
     return 0
 
 
+def _first_run_downloads(model: str) -> list[str]:
+    """Human-readable one-time downloads the next search will trigger.
+
+    Best-effort: peeks at fastembed's model cache and the search-DB cache;
+    any surprise in their layout just means the notice is skipped.
+    """
+    from .search import search_available  # noqa: PLC0415
+
+    pending = []
+    try:
+        from fastembed import TextEmbedding  # noqa: PLC0415
+        from fastembed.common.utils import define_cache_dir  # noqa: PLC0415
+
+        fastembed_name = EMBEDDING_MODELS[model].fastembed_model
+        meta = next(
+            m
+            for m in TextEmbedding.list_supported_models()
+            if m["model"] == fastembed_name
+        )
+        hf_repo = (meta.get("sources") or {}).get("hf") or ""
+        size_mb = round(meta["size_in_GB"] * 1000)
+        model_dir = (
+            pathlib.Path(define_cache_dir(None))
+            / f"models--{hf_repo.replace('/', '--')}"
+        )
+        if hf_repo and not model_dir.exists():
+            pending.append(f"embedding model (~{size_mb} MB)")
+    except Exception:
+        pass
+    if not search_available():
+        pending.append("search index (11 MB)")
+    return pending
+
+
 def _cmd_search(args: argparse.Namespace) -> int:
     """Handle ``lucide search``."""
     import os  # noqa: PLC0415
@@ -548,6 +582,19 @@ def _cmd_search(args: argparse.Namespace) -> int:
             candidate = icons_db.parent / "lucide-search.db"
             if candidate.exists():
                 os.environ["LUCIDE_SEARCH_DB_PATH"] = str(candidate)
+
+    # Downloading without a token is expected here; the hf_xet download
+    # backend's HF_TOKEN nudge reads like an error mid-download, so keep
+    # warnings from its logger out of the way
+    logging.getLogger("hf_xet").setLevel(logging.ERROR)
+
+    pending = _first_run_downloads(args.model)
+    if pending:
+        print(
+            f"First run: downloading {' and '.join(pending)} — "
+            "cached for future searches.",
+            file=sys.stderr,
+        )
 
     try:
         results = search_icons(args.query, limit=args.limit, model=args.model)
@@ -572,7 +619,7 @@ def _cmd_search(args: argparse.Namespace) -> int:
     for r in results:
         if show_icons and r.name in svgs:
             _display_kitty_image(svgs[r.name])
-        print(f"  {bold}{cyan}{r.name}{reset}  {dim}{r.score:.3f}{reset}")
+        print(f"  {bold}{cyan}{r.name}{reset}  {dim}{r.score:.0%}{reset}")
         if args.verbose and r.description:
             print(f"    {dim}{r.description[:100]}{reset}")
         if show_icons:

--- a/src/lucide/search.py
+++ b/src/lucide/search.py
@@ -280,7 +280,7 @@ def search_icons(
     """Search for icons by natural language query.
 
     On the first call the search database is downloaded and cached in
-    ``~/.cache/python-lucide/``.  The embedding model (~35-130 MB depending
+    ``~/.cache/python-lucide/``.  The embedding model (~67-220 MB depending
     on *model*) is also downloaded once by *fastembed*.
 
     Args:


### PR DESCRIPTION
## Summary
- **README finally advertises semantic search.** New "Semantic Search" section with the no-install one-liner (`uvx --from "python-lucide[search]" lucide search "..."`), the `[search]` extra, example output, `--model`/`--limit`/`--verbose` options, the kitty-graphics inline icon rendering, the Python API, and a link to the browser version. Features list gets a search bullet linking to the web app.
- **First-run notice**: `lucide search` announces one-time downloads before they start — "First run: downloading embedding model (~67 MB) and search index (11 MB) — cached for future searches." Written to stderr so piped stdout stays clean. Model size and cache state come from fastembed's own registry/cache-dir APIs (best-effort: any layout surprise just skips the notice). Previously the 11 MB index downloaded behind an invisible `logger.info`.
- **Noise removal**: the hf_xet "set HF_TOKEN" nudge printed twice mid-download and read like an error; silencing the `hf_xet` logger kills both copies (its own handler plus root propagation). fastembed's actual download progress bars are kept.
- **Scores print as percentages** (`67%` not `0.667`), matching the web app.

## Test plan
- [x] Cold-cache run (model + DB wiped): notice lists both downloads, no HF warnings, correct results (trophy 67%, award 65%, medal 65%)
- [x] Warm run: results only, no notice, no noise
- [x] `make test` — 77 passed; `make run-hooks-all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)