### PR TITLE
chore: release v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ license = {text = "MIT"}
 name = "python-lucide"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.4.0"
+version = "0.5.0"
 
 [project.optional-dependencies]
 search = ["cairosvg>=2.7.0", "fastembed>=0.4.0"]


### PR DESCRIPTION
Version bump for the v0.5.0 release. Highlights since v0.4.0:

## CLI
- Inline icons in `lucide search` results: one row tall next to the name, in kitty/Ghostty/WezTerm — **including inside tmux** via passthrough (#166)
- cairosvg ships with the `[search]` extra; actionable stderr tips when the terminal could show icons but something's missing (#166)
- Percent match scores, first-run download notice, quieter hf_xet logging (#164)

## Web app
- Search app now served at https://mmacpherson.github.io/python-lucide/ (root), `/search/` redirects (#169)
- Browsable gallery + byte-accurate download progress while the model loads (#162), FLIP transitions (#163), q8 models with two-model consolidation (#158, #159), mobile layout fixes (#157), assorted polish (#155, #156, #160, #161)

## Docs
- Semantic Search README section with web and terminal screenshots (#164, #165, #167, #168)

After merge: trigger the publish workflow to push to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)