### PR TITLE
fix(ci): make PyPI publish idempotent with --check-url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,11 @@ jobs:
         # Test that the built package can be installed and imported
         uv run --with ./dist/*.whl --no-project -- python -c "import lucide; print('✅ Package imports successfully')"
 
+      # --check-url skips files already on PyPI, so a release-created run
+      # after a manual dispatch (or a re-run) doesn't fail on duplicates
     - name: Publish package to PyPI
       run: |
-        uv publish
+        uv publish --check-url https://pypi.org/simple/
 
     # Optional: Create GitHub Release with assets
     - name: Upload assets to GitHub Release


### PR DESCRIPTION
A release-created event triggers publish.yml; if the version is already on PyPI (manual dispatch first, or a re-run), `uv publish` fails on duplicate files before the asset-upload steps run. `--check-url` makes uv skip files already present on the index. Needed to create the v0.5.0 GitHub release without a red run, since 0.5.0 is already live on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)