### PR TITLE
feat(web): move Explore hint to top of plot, lead with neighbors

### DIFF
--- a/web/src/pages/ExplorePage.svelte
+++ b/web/src/pages/ExplorePage.svelte
@@ -434,7 +434,7 @@
     {:else if !loaded}
       <div class="canvas-loading">Loading embedding space...</div>
     {/if}
-    <div class="ex-hint">Click to select &middot; Shift+click multi-select &middot; Scroll to zoom &middot; Drag to pan</div>
+    <div class="ex-hint">Click an icon to see its nearest neighbors &middot; Shift+click multi-select &middot; Scroll to zoom &middot; Drag to pan</div>
   </div>
 </div>
 
@@ -561,7 +561,7 @@
   }
   .retry:hover { background: #ff6b6b; color: #fff; }
   .ex-hint {
-    position: absolute; bottom: 14px; left: 50%; transform: translateX(-50%);
+    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
     font-size: 11.5px; color: var(--tx3); white-space: nowrap; pointer-events: none;
   }
 


### PR DESCRIPTION
The interaction hint moves from the bottom edge of the canvas (easy to miss) to the top, and now opens with what selection actually does: "Click an icon to see its nearest neighbors" instead of "Click to select".

Verified position (14px from canvas top) and wording with Playwright against `vite preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)